### PR TITLE
Add `page_type` metadata to Solr Docs and Solr Registry

### DIFF
--- a/catalog-legacy/pom.xml
+++ b/catalog-legacy/pom.xml
@@ -60,7 +60,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -150,34 +150,34 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.23.1</version>
+      <version>2.24.0</version>
     </dependency>
 
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.0</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.0</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>gov.nasa.pds</groupId>
       <artifactId>pds3-product-tools</artifactId>
-      <version>4.3.0</version>
+      <version>4.4.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -190,7 +190,7 @@
     <dependency>
       <groupId>org.incava</groupId>
       <artifactId>java-diff</artifactId>
-      <version>1.1</version>
+      <version>1.1.2</version>
       <scope>compile</scope>
     </dependency>
 
@@ -211,7 +211,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
-      <version>9.6.0</version>
+      <version>9.7.0</version>
     </dependency>
     
 	<dependency>

--- a/catalog-legacy/src/main/java/gov/nasa/pds/citool/diff/ValueDiff.java
+++ b/catalog-legacy/src/main/java/gov/nasa/pds/citool/diff/ValueDiff.java
@@ -1,16 +1,14 @@
 package gov.nasa.pds.citool.diff;
 
-import gov.nasa.pds.tools.label.Value;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.incava.util.diff.Diff;
-import org.incava.util.diff.Difference;
+import org.incava.diff.Diff;
+import org.incava.diff.Difference;
+import gov.nasa.pds.tools.label.Value;
 
 public class ValueDiff {
     public static List<DiffRecord> diff(Value source, Value target) {

--- a/catalog-legacy/src/main/resources/search-conf/defaults/pds/dataset.xml
+++ b/catalog-legacy/src/main/resources/search-conf/defaults/pds/dataset.xml
@@ -47,6 +47,9 @@
     <field name="data_object_type" type="string">
       <registryPath>objectType</registryPath>
     </field>
+    <field name="page_type" type="string">
+      <outputString format="text">Data Set</outputString>
+    </field>
     <field name="pds_model_version" type="string">
       <outputString format="text">pds3</outputString>
     </field>

--- a/harvest-legacy/pom.xml
+++ b/harvest-legacy/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
 	    <groupId>org.codehaus.mojo</groupId>
 	    <artifactId>buildnumber-maven-plugin</artifactId>
-	    <version>3.2.0</version>
+	    <version>3.2.1</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -148,13 +148,13 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -222,7 +222,7 @@
     <dependency>
       <artifactId>solr-core</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.6.1</version>
+      <version>9.7.0</version>
       <type>jar</type>
       <scope>compile</scope>
       <exclusions>
@@ -235,7 +235,7 @@
     <dependency>
       <artifactId>solr-solrj</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.6.0</version>
+      <version>9.7.0</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
@@ -252,7 +252,7 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.28.5</version>
+      <version>2.8.0</version>
     </dependency>
 	<!-- https://mvnrepository.com/artifact/com.google.common/google-collect -->
 	<dependency>
@@ -264,13 +264,13 @@
 	<dependency>
 	    <groupId>org.springframework</groupId>
 	    <artifactId>spring-core</artifactId>
-	    <version>6.1.11</version>
+	    <version>6.1.13</version>
 	</dependency>
 	    <!-- https://mvnrepository.com/artifact/org.springframework/spring-context -->
 	<dependency>
 	    <groupId>org.springframework</groupId>
 	    <artifactId>spring-context</artifactId>
-	    <version>6.1.11</version>
+	    <version>6.1.13</version>
 	</dependency>
 
 	<dependency>

--- a/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/constants/Constants.java
+++ b/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/constants/Constants.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 import gov.nasa.pds.harvest.search.util.LidVid;
 import gov.nasa.pds.registry.model.ExtrinsicObject;
 
@@ -102,6 +101,9 @@ public class Constants {
    */
   public static final String BYTE = "byte";
 
+  /** Page type of the object. */
+  public static final String COLLECTION_PAGE_TYPE = "page_type";
+
   /**
    * The XPath to the data classes in the PDS4 label.
    */
@@ -126,6 +128,12 @@ public class Constants {
     "//Inventory[reference_type='inventory_has_LIDVID_Secondary'] "
     + " | //Inventory[reference_type='inventory_has_LID_Secondary']";
 
+  /**
+   * XPath for determining collection page type
+   */
+  public static final String COLLECTION_PAGE_TYPE_XPATH =
+      "if (//Collection/collection_type = 'Document' ) then \"Resource\" else \"Data Collection\"";
+
   static {
     coreXpathsMap.put(LOGICAL_ID, IDENTIFICATION_AREA_XPATH + "/"
         + LOGICAL_ID);
@@ -140,6 +148,7 @@ public class Constants {
     coreXpathsMap.put(FILE_OBJECTS, "//*[starts-with(name(), 'File_Area')]/"
         + "File | //Document_File");
     coreXpathsMap.put(DATA_CLASS, DATA_CLASS_XPATH);
+    coreXpathsMap.put(COLLECTION_PAGE_TYPE, COLLECTION_PAGE_TYPE_XPATH);
   }
 
   public static final String URN_ILLEGAL_CHARACTERS = "[%/\\\\?#\"&<>\\[\\]^`\\{\\|\\}~]";

--- a/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/crawler/metadata/extractor/CollectionMetExtractor.java
+++ b/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/crawler/metadata/extractor/CollectionMetExtractor.java
@@ -58,6 +58,7 @@ public class CollectionMetExtractor extends Pds4MetExtractor {
     String version = "";
     String title = "";
     String associationType = "";
+    String collectionPageType = "";
     List<TinyElementImpl> references = new ArrayList<TinyElementImpl>();
     List<Slot> slots = new ArrayList<Slot>();
     try {
@@ -77,6 +78,8 @@ public class CollectionMetExtractor extends Pds4MetExtractor {
       associationType = extractor.getValueFromDoc(ASSOCIATION_TYPE_XPATH);
       references = extractor.getNodesFromDoc(Constants.coreXpathsMap.get(
           Constants.REFERENCES));
+      collectionPageType =
+          extractor.getValueFromDoc(Constants.coreXpathsMap.get(Constants.COLLECTION_PAGE_TYPE));
     } catch (Exception x) {
       //TODO: getMessage() doesn't always return a message
       throw new MetExtractionException(x.getMessage());
@@ -120,6 +123,9 @@ public class CollectionMetExtractor extends Pds4MetExtractor {
     }
     if ((!"".equals(objectType)) && (config.hasObjectType(objectType))) {
       slots.addAll(extractMetadata(config.getMetXPaths(objectType)));
+    }
+    if (!"".equals(collectionPageType)) {
+      metadata.addMetadata(Constants.COLLECTION_PAGE_TYPE, collectionPageType);
     }
     List<ReferenceEntry> refEntries = new ArrayList<ReferenceEntry>();
     try {

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds3/dataset.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds3/dataset.xml
@@ -37,6 +37,9 @@
     <field name="data_product_type" type="required">
       <outputString format="text">Data_Set</outputString>
     </field>
+    <field name="page_type" type="required">
+      <outputString format="text">Data Set</outputString>
+    </field>
     <field name="data_class" type="string">
       <registryPath>data_class</registryPath>
     </field>

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/bundle.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/bundle.xml
@@ -37,6 +37,9 @@
     <field name="data_product_type" type="string">
       <outputString format="text">Bundle</outputString>
     </field>
+    <field name="page_type" type="string">
+      <outputString format="text">Data Bundle</outputString>
+    </field>
     <field name="objectType" type="string">
       <registryPath>objectType</registryPath>
     </field>

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/collection.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/collection.xml
@@ -38,6 +38,9 @@
     <field name="data_product_type" type="string">
       <outputString format="text">Collection</outputString>
     </field>
+    <field name="page_type" type="string">
+      <registryPath>page_type</registryPath>
+    </field>
     <field name="objectType" type="string">
       <registryPath>objectType</registryPath>
     </field>

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/context.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/context.xml
@@ -42,6 +42,9 @@
     <field name="data_class" type="string">
       <registryPath>data_class</registryPath>
     </field>
+    <field name="page_type" type="string">
+      <registryPath>data_class</registryPath>
+    </field>
     <field name="objectType" type="string">
       <registryPath>objectType</registryPath>
     </field>

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/document.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/document.xml
@@ -37,6 +37,9 @@
     <field name="data_product_type" type="string">
       <outputString format="text">Document</outputString>
     </field>
+    <field name="page_type" type="string">
+      <outputString format="text">Resource</outputString>
+    </field>
     <field name="objectType" type="string">
       <registryPath>objectType</registryPath>
     </field>

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/service.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/service.xml
@@ -35,6 +35,9 @@
     <field name="data_product_type" type="string">
       <outputString format="text">Service</outputString>
     </field>
+    <field name="page_type" type="string">
+      <outputString format="text">Tool</outputString>
+    </field>
     <field name="data_class" type="string">
       <registryPath>data_class</registryPath>
     </field>

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/software.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/software.xml
@@ -34,6 +34,9 @@
     <field name="alternate_title" type="string">
       <registryPath>alternate_title</registryPath>
     </field>
+    <field name="page_type" type="string">
+      <outputString format="text">Tool</outputString>
+    </field>
     <!-- Search -->
     <field name="description" type="required">
       <registryPath>software_description</registryPath>

--- a/registry-mgr-legacy/pom.xml
+++ b/registry-mgr-legacy/pom.xml
@@ -39,7 +39,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -114,14 +114,14 @@
     <dependency>
       <artifactId>solr-core</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.6.1</version>
+      <version>9.7.0</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <artifactId>solr-solrj</artifactId>
       <groupId>org.apache.solr</groupId>
-      <version>9.6.0</version>
+      <version>9.7.0</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
@@ -129,17 +129,17 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.26.2</version>
+      <version>1.27.1</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>

--- a/registry-mgr-legacy/src/main/resources/build/Dockerfile
+++ b/registry-mgr-legacy/src/main/resources/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:9.6.0
+FROM solr:9.7.0
 ADD VERSION.txt .
 
 # Config sets

--- a/registry-mgr-legacy/src/main/resources/collections/data/managed-schema
+++ b/registry-mgr-legacy/src/main/resources/collections/data/managed-schema
@@ -148,6 +148,7 @@
    <field name="observing_system_name" type="text_en_splitting" indexed="true" stored="true" multiValued="true" />
    <field name="observing_system_component_name" type="text_en_splitting" indexed="true" stored="true" multiValued="true" />
    <field name="observing_system_component_type" type="text_en_splitting" indexed="true" stored="true" multiValued="true" />
+   <field name="page_type" type="lowercase" indexed="true" stored="true" multiValued="true" />
 
    <!-- PDS Affiliate -->
    <field name="person_name" type="text_gen_sort" indexed="true" stored="true" multiValued="true" />

--- a/registry-mgr-legacy/src/main/resources/collections/data/solrconfig.xml
+++ b/registry-mgr-legacy/src/main/resources/collections/data/solrconfig.xml
@@ -793,8 +793,8 @@
        <str name="facet.field">instrument_ref</str>
        <str name="facet.field">target_ref</str>
        <str name="facet.field">page_type</str>
-       <str name="facet.field">primary_result_purpose</str>
-       <str name="facet.field">primary_result_processing_level</str>
+       <str name="facet.field">facet_primary_result_purpose</str>
+       <str name="facet.field">facet_primary_result_processing_level</str>
     </lst>
 
     <lst name="appends">

--- a/registry-mgr-legacy/src/main/resources/collections/data/solrconfig.xml
+++ b/registry-mgr-legacy/src/main/resources/collections/data/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>9.6.0</luceneMatchVersion>
+  <luceneMatchVersion>9.7.0</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in
@@ -775,6 +775,54 @@
     </lst>
 
   </requestHandler>
+  
+  <requestHandler name="/keyword" class="solr.SearchHandler">
+
+    <lst name="defaults">
+       <str name="df">text</str> 
+       <str name="echoParams">explicit</str>
+       <str name="defType">edismax</str>
+       <str name="q.alt">*:*</str>
+       <str name="fl">*,score</str>
+       <str name="wt">json</str>
+       <str name="start">0</str>
+       <str name="rows">50</str>
+       <str name="facet">true</str>
+       <str name="facet.mincount">1</str>
+       <str name="facet.field">investigation_ref</str>
+       <str name="facet.field">instrument_ref</str>
+       <str name="facet.field">target_ref</str>
+       <str name="facet.field">page_type</str>
+       <str name="facet.field">primary_result_purpose</str>
+       <str name="facet.field">primary_result_processing_level</str>
+    </lst>
+
+    <lst name="appends">
+      <!-- Update params to include filter query restricting to latest product versions -->
+      <str name="fq">{!collapse field=lid max=version_id_normalized}</str>
+      <str name="fq">-archive_status:SUPERSEDED</str>
+      <!-- Filter out Observational and Document products and all of the various  -->
+      <str name="fq">-data_product_type:Product_Observational</str>
+      <str name="fq">-data_product_type:Resource</str>
+      <!-- Ignore PDS3 context products -->
+      <str name="fq">-product_class:Product_Mission_PDS3 AND -product_class:Product_Instrument_Host_PDS3 AND -product_class:Product_Instrument_PDS3 AND -product_class:Product_Target_PDS3</str>
+      <!-- Service entries should not be showed up in the search-ui results for now -->
+      <str name="fq">-data_product_type:Agency AND -data_product_type:Node AND -data_product_type:Other AND -data_product_type:PDS_Affiliate AND -data_product_type:PDS_Guest</str>
+      <str name="fq">-resource_type:Information.Science_Portal</str>
+      <str name="fq">-objectType:Product_Attribute_Definition AND -objectType:Product_Class_Definition</str>
+      
+      <!-- Boosts -->
+      <str name="bq">data_product_type:Product_Context_Search_Tool^100</str> <!-- Search Tools -->
+      <str name="bq">product_class:Product_Context^100</str>
+      <str name="bq">product_class:Product_Bundle^90</str>
+      <str name="bq">product_class:Product_Collection^80</str>
+      <str name="bq">data_product_type:Resource^10</str>
+    </lst>
+
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
 
   <requestHandler name="/search" class="gov.nasa.pds.search.PDSSearchProtocol" default="true">
     <!-- could eventually move this to initParams if desired -->
@@ -875,7 +923,7 @@
       <str name="fq">-data_product_type:Product_Observational</str>
       <!-- Service entries should not be showed up in the search-ui results for now -->
       <str name="fq">-data_product_type:Service</str>
-      <str name="fq">-data_product_type:Agency AND -data_product_type:Facility AND -data_product_type:Node AND -data_product_type:Other AND -data_product_type:PDS_Affiliate AND -data_product_type:PDS_Guest AND -data_product_type:Telescope AND -data_product_type:Airborne</str>
+      <str name="fq">-data_product_type:Agency AND -data_product_type:Node AND -data_product_type:Other AND -data_product_type:PDS_Affiliate AND -data_product_type:PDS_Guest</str>
       <str name="fq">-resource_type:Information.Science_Portal</str>
       <str name="fq">-objectType:Product_Attribute_Definition AND -objectType:Product_Class_Definition</str>
       <str name="bq">data_product_type:Product_Context_Search_Tool^100</str>

--- a/registry-mgr-legacy/src/main/resources/collections/registry/solrconfig.xml
+++ b/registry-mgr-legacy/src/main/resources/collections/registry/solrconfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <config>
-  <luceneMatchVersion>9.6.0</luceneMatchVersion>
+  <luceneMatchVersion>9.7.0</luceneMatchVersion>
 
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />

--- a/search-core/pom.xml
+++ b/search-core/pom.xml
@@ -57,7 +57,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>validate</phase>

--- a/src/test/resources/data/test1/expected/solr_doc_expected.xml
+++ b/src/test/resources/data/test1/expected/solr_doc_expected.xml
@@ -13,7 +13,6 @@
 <field name="instrument_ref">urn:nasa:pds:context:instrument:leam.a17a</field>
 <field name="file_ref_size">11400</field>
 <field name="file_ref_size">241</field>
-<field name="modification_date">2015-05-22T00:00:00.000Z</field>
 <field name="external_reference_text">Apollo 17 Preliminary Science Report, NASA SP-330, published by NASA,
       Washington, D.C., 1973.</field>
 <field name="external_reference_text">Apollo Scientific Experiments Data Handbook, NASA Technical Memorandum
@@ -69,6 +68,7 @@
 <field name="observation_start_date_time">1972-12-07T00:00:00.000Z</field>
 <field name="target_name">Moon</field>
 <field name="target_name">Dust</field>
+<field name="page_type">Data Collection</field>
 <field name="collection_member_count">4</field>
 <field name="description">Fake test collection</field>
 <field name="citation_publication_year">2017</field>
@@ -104,7 +104,6 @@
 <field name="objectType">Product_Context</field>
 <field name="product_class">Product_Context</field>
 <field name="file_ref_size">1579</field>
-<field name="modification_date">2020-09-09T00:00:00.000Z</field>
 <field name="file_ref_name">resource_a17leamcal.xml</field>
 <field name="resource_url">https://pds-geosciences.wustl.edu/missions/apollo/index.htm</field>
 <field name="modification_description">
@@ -115,6 +114,7 @@
 <field name="resource_description">
             Initial version of Apollo 17 Lunar Ejecta And Meteorites Experiment Calibration Notebook
         </field>
+<field name="page_type">Resource</field>
 <field name="description">
             Initial version of Apollo 17 Lunar Ejecta And Meteorites Experiment Calibration Notebook
         </field>
@@ -139,7 +139,6 @@
 <field name="instrument_ref">urn:nasa:pds:context:instrument:leam.a17a</field>
 <field name="file_ref_size">5346</field>
 <field name="file_ref_size">600</field>
-<field name="modification_date">2015-05-22T00:00:00.000Z</field>
 <field name="file_ref_name">bundle.xml</field>
 <field name="file_ref_name">readme.txt</field>
 <field name="observation_stop_date_time">1977-09-30T00:00:00.000Z</field>
@@ -159,6 +158,7 @@
 <field name="observation_start_date_time">1972-12-07T00:00:00.000Z</field>
 <field name="target_name">Moon</field>
 <field name="target_name">Dust</field>
+<field name="page_type">Data Bundle</field>
 <field name="description">This bundle contains a digital reproduction of one hand-written laboratory
       notebook of calibration analysis for the Apollo 17 Lunar Ejecta And Meteorites (LEAM)
       Experiment detector, which was identical to Pioneer 8 and 9 Cosmic Dust Detectors
@@ -191,7 +191,6 @@
 <field name="objectType">Product_Context</field>
 <field name="product_class">Product_Context</field>
 <field name="file_ref_size">1592</field>
-<field name="modification_date">2020-09-09T00:00:00.000Z</field>
 <field name="file_ref_name">resource_a17leamcal_2.xml</field>
 <field name="resource_url">https://pds-geosciences.wustl.edu/lunar/urn-nasa-pds-a17leamcal/</field>
 <field name="modification_description">
@@ -202,6 +201,7 @@
 <field name="resource_description">
             Initial version of Apollo 17 Lunar Ejecta And Meteorites Experiment Calibration Notebook 2
         </field>
+<field name="page_type">Resource</field>
 <field name="description">
             Initial version of Apollo 17 Lunar Ejecta And Meteorites Experiment Calibration Notebook 2
         </field>
@@ -227,7 +227,6 @@
 <field name="instrument_ref">urn:nasa:pds:context:instrument:leam.a17a</field>
 <field name="file_ref_size">11875</field>
 <field name="file_ref_size">269</field>
-<field name="modification_date">2015-05-22T00:00:00.000Z</field>
 <field name="external_reference_text">Apollo 17 Preliminary Science Report, NASA SP-330, published by NASA,
       Washington, D.C., 1973.</field>
 <field name="external_reference_text">Apollo Scientific Experiments Data Handbook, NASA Technical Memorandum
@@ -288,6 +287,7 @@
 <field name="observation_start_date_time">1972-12-07T00:00:00.000Z</field>
 <field name="target_name">Moon</field>
 <field name="target_name">Dust</field>
+<field name="page_type">Data Collection</field>
 <field name="collection_member_count">4</field>
 <field name="description">This collection contains a digital reproduction of one hand-written laboratory
       notebook of calibration analysis by Dr. Otto E. Berg for the Apollo 17 Lunar Ejecta And

--- a/src/test/resources/data/test2/expected/solr_doc_expected.xml
+++ b/src/test/resources/data/test2/expected/solr_doc_expected.xml
@@ -843,7 +843,6 @@ instrumentation for radio science investigations.
 <field name="instrument_host_name">JUNO</field>
 <field name="instrument_host_type">SPACECRAFT</field>
 <field name="lid">urn:nasa:pds:context_pds3:instrument_host:spacecraft.jno</field>
-<field name="modification_date">2024-08-08T12:50:49.037Z</field>
 <field name="modification_description">2012-06-01 JUNO: kurth    Revision 1;
 2016-08-03 JUNO: Redfern Revision 2;
 2017-02-02 PDS: INSTRUMENT_HOST_NAME reverted to &apos;JUNO&apos;
@@ -1076,7 +1075,6 @@ Standard Data Products (Daubar et al. 2022) for more information.</field>
 <field name="instrument_name">STELLAR REFERENCE UNIT</field>
 <field name="instrument_type">CAMERA</field>
 <field name="lid">urn:nasa:pds:context_pds3:instrument:instrument.sru.jno</field>
-<field name="modification_date">2024-08-08T12:50:49.037Z</field>
 <field name="modification_description">2022-01-01</field>
 <field name="objectType">Product_Instrument_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -1181,7 +1179,6 @@ Standard Data Products (Daubar et al. 2022) for more information.</field>
 <field name="investigation_start_date">2011-08-05T00:00:00.000Z</field>
 <field name="investigation_stop_date">3000-01-01T00:00:00.000Z</field>
 <field name="lid">urn:nasa:pds:context_pds3:data_set:data_set.jno-j-sru-edr-2-l0-v1.0</field>
-<field name="modification_date">2024-08-08T12:50:49.037Z</field>
 <field name="modification_description">2022-01-21</field>
 <field name="objectType">Product_Data_Set_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -2183,7 +2180,6 @@ Mission Phases
 <field name="investigation_start_date">2011-08-05T00:00:00.000Z</field>
 <field name="investigation_stop_date">3000-01-01T00:00:00.000Z</field>
 <field name="lid">urn:nasa:pds:context_pds3:investigation:mission.juno</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">2012-03-12 JUNO:    Kurth Revision 1;
   2015-08-15 JUNO:    Kurth and Stephens Revision 2;
   2016-10-13 PDS:     Mafi Revision 3;
@@ -2284,7 +2280,6 @@ Mission Phases
 <field name="investigation_start_date">2011-08-05T00:00:00.000Z</field>
 <field name="investigation_stop_date">3000-01-01T00:00:00.000Z</field>
 <field name="lid">urn:nasa:pds:context_pds3:data_set:data_set.jno-j-sru-countrate-table-5-l2-v1.0</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">2022-01-01</field>
 <field name="objectType">Product_Data_Set_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -2375,7 +2370,6 @@ Mission Phases
 <field name="external_reference_text">BROADFOOTETAL1979</field>
 <field name="external_reference_text">SCHNEIDER&amp;TRAUGE1995</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:plasma_cloud.io_plasma_torus</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">CREATED: 2001-06-06, J. MAFI</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -2457,7 +2451,6 @@ Mission Phases
       missions.</field>
 <field name="external_reference_text">N/A</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:n-a.solar_wind</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">30 January 2003 S. L. Adams - Skeleton
 28 Jan 2005, A.C.Raugh  Corrected to standards and expanded according to
 apparent use.</field>
@@ -2636,7 +2629,6 @@ apparent use.</field>
        gravitational constant, G, comes from page K6.</field>
 <field name="external_reference_text">UNK</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:planet.jupiter</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">2007-06-08 Maud Barthelemy</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -2829,7 +2821,6 @@ apparent use.</field>
     Geometric Visual Albedo:       0.12</field>
 <field name="external_reference_text">LANG1992</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:satellite.moon</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">10 Mar 1999, A.C.Raugh First draft from available information</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -2888,7 +2879,6 @@ apparent use.</field>
     Sagittarius) at a mean speed of about 220 km/sec.</field>
 <field name="external_reference_text">UNK</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:planetary_system.solar_system</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">2001-01-01, S. JOY (PPI), initial release;</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -2969,7 +2959,6 @@ apparent use.</field>
           albedo:           0.17</field>
 <field name="external_reference_text">LANG1992</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:satellite.callisto</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">2009-03-27   A.C.Raugh   Recreated from reference</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -3048,7 +3037,6 @@ apparent use.</field>
         Geometric Visual Albedo:     0.64</field>
 <field name="external_reference_text">LANG1992</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:satellite.europa</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">10 Mar 1999, A.C.Raugh First draft from available information</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -3183,7 +3171,6 @@ apparent use.</field>
         DATA_SOURCE_ID                  : PERIARGANG-PLANET</field>
 <field name="external_reference_text">UNK</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:planet.earth</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">2007-06-08 Maud Barthelemy</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -3300,7 +3287,6 @@ apparent use.</field>
 <field name="description">N/A</field>
 <field name="external_reference_text">N/A</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:ring.j_rings</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">20 Apr 2007  B.Carcich,  Creation</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -3361,7 +3347,6 @@ apparent use.</field>
           albedo:           0.43</field>
 <field name="external_reference_text">LANG1992</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:satellite.ganymede</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">2009-03-27   A.C.Raugh   Recreated from reference</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -3425,7 +3410,6 @@ apparent use.</field>
     datasets concerned with observations of any kind of cosmic dust.</field>
 <field name="external_reference_text">N/A</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:dust.dust</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">10 Mar 1999, A.C.Raugh, First draft from available information.</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>
@@ -3449,7 +3433,6 @@ apparent use.</field>
 <field name="description">UNK</field>
 <field name="external_reference_text">UNK</field>
 <field name="lid">urn:nasa:pds:context_pds3:target:satellite.io</field>
-<field name="modification_date">2024-08-08T12:50:49.038Z</field>
 <field name="modification_description">NULL</field>
 <field name="objectType">Product_Target_PDS3</field>
 <field name="pds_model_version">pds3</field>

--- a/src/test/resources/data/test2/expected/solr_doc_expected.xml
+++ b/src/test/resources/data/test2/expected/solr_doc_expected.xml
@@ -1181,6 +1181,7 @@ Standard Data Products (Daubar et al. 2022) for more information.</field>
 <field name="lid">urn:nasa:pds:context_pds3:data_set:data_set.jno-j-sru-edr-2-l0-v1.0</field>
 <field name="modification_description">2022-01-21</field>
 <field name="objectType">Product_Data_Set_PDS3</field>
+<field name="page_type">Data Set</field>
 <field name="pds_model_version">pds3</field>
 <field name="product_class">Product_Data_Set_PDS3</field>
 <field name="resLocation">/ds-view/pds/viewDataset.jsp?dsid=JNO-J-SRU-EDR-2-L0-V1.0</field>
@@ -2282,6 +2283,7 @@ Mission Phases
 <field name="lid">urn:nasa:pds:context_pds3:data_set:data_set.jno-j-sru-countrate-table-5-l2-v1.0</field>
 <field name="modification_description">2022-01-01</field>
 <field name="objectType">Product_Data_Set_PDS3</field>
+<field name="page_type">Data Set</field>
 <field name="pds_model_version">pds3</field>
 <field name="product_class">Product_Data_Set_PDS3</field>
 <field name="resLocation">/ds-view/pds/viewDataset.jsp?dsid=JNO-J-SRU-COUNTRATE-TABLE-5-L2-V1.0</field>

--- a/test/smoke-tests.sh
+++ b/test/smoke-tests.sh
@@ -44,7 +44,7 @@ echo "[SUCCESS] Harvest Successful"
 echo "[INFO] Check solr docs match expected"
 SOLR_EXPECTED=$PARENTDIR/src/test/resources/data/test1/expected/solr_doc_expected.xml
 # Cleanse output file of elements that are specific to where the code is run
-egrep -v package_id $OUTDIR/solr-docs/solr_doc_0.xml | egrep -v file_ref_location | egrep -v file_ref_url > solr_doc_actual.xml
+egrep -v package_id $OUTDIR/solr-docs/solr_doc_0.xml | egrep -v file_ref_location | egrep -v file_ref_url | egrep -v modification_date > solr_doc_actual.xml
 
 # Diff
 test=$(diff solr_doc_actual.xml $SOLR_EXPECTED)

--- a/test/smoke-tests.sh
+++ b/test/smoke-tests.sh
@@ -22,56 +22,52 @@ OUTDIR=$DATA_HOME/test1
 mkdir -p $OUTDIR
 
 # Install Solr with preconfigured collections
-#$LEGACY_REGISTRY_HOME/bin/registry_legacy_installer_docker.sh install
-#check_status $? "[ERROR] Registry Manager Install Failure"
-#
-#echo "+++ TEST 1 - PDS4 +++"
-#TEST_DATA_HOME=$PARENTDIR/src/test/resources/data/test1/a17leamcal_custom
-#TEST_DATA_HOME=${TEST_DATA_HOME//\//\\\/}
-#
-## Create config file based upon current environment
-#sed "s/{TEST_DATA_HOME}/$TEST_DATA_HOME/g" $PARENTDIR/src/test/resources/conf/harvest-policy-master.xml > test-policy.xml
-#echo "[INFO] Created new config file with TEST_DATA_HOME=$TEST_DATA_HOME"
-#
-#echo "[INFO] Harvest test data"
-#$LEGACY_HARVEST_HOME/bin/harvest-solr -c $(pwd)/test-policy.xml \
-#                                      -C $LEGACY_HARVEST_HOME/conf/search/defaults \
-#                                      -o $OUTDIR --verbose 0
-#
-#check_status $? "[ERROR] Harvest Failure"
-#echo "[SUCCESS] Harvest Successful"
-#
-#echo "[INFO] Check solr docs match expected"
-#SOLR_EXPECTED=$PARENTDIR/src/test/resources/data/test1/expected/solr_doc_expected.xml
-## Cleanse output file of elements that are specific to where the code is run
-#egrep -v package_id $OUTDIR/solr-docs/solr_doc_0.xml | egrep -v file_ref_location | egrep -v file_ref_url > solr_doc_actual.xml
-#
-## Diff
-#test=$(diff solr_doc_actual.xml $SOLR_EXPECTED)
-#if [ -z "$test" ]; then
-#    echo "[SUCCESS] Harvest Solr Doc Diff Successful"
-#else
-#    echo "[ERROR] Harvest Solr Doc Diff Test Failed"
-#    echo $test
-#    exit 1
-#fi
-#
-#
-## Load test data
-#echo "[INFO] Registry Manager Load"
-#$LEGACY_REGISTRY_HOME/bin/registry-mgr-solr $OUTDIR
-#
-#check_status $? "[ERROR] Registry Manager Load Failure"
+$LEGACY_REGISTRY_HOME/bin/registry_legacy_installer_docker.sh install
+check_status $? "[ERROR] Registry Manager Install Failure"
+
+echo "+++ TEST 1 - PDS4 +++"
+TEST_DATA_HOME=$PARENTDIR/src/test/resources/data/test1/a17leamcal_custom
+TEST_DATA_HOME=${TEST_DATA_HOME//\//\\\/}
+
+# Create config file based upon current environment
+sed "s/{TEST_DATA_HOME}/$TEST_DATA_HOME/g" $PARENTDIR/src/test/resources/conf/harvest-policy-master.xml > test-policy.xml
+echo "[INFO] Created new config file with TEST_DATA_HOME=$TEST_DATA_HOME"
+
+echo "[INFO] Harvest test data"
+$LEGACY_HARVEST_HOME/bin/harvest-solr -c $(pwd)/test-policy.xml \
+                                      -C $LEGACY_HARVEST_HOME/conf/search/defaults \
+                                      -o $OUTDIR --verbose 0
+
+check_status $? "[ERROR] Harvest Failure"
+echo "[SUCCESS] Harvest Successful"
+
+echo "[INFO] Check solr docs match expected"
+SOLR_EXPECTED=$PARENTDIR/src/test/resources/data/test1/expected/solr_doc_expected.xml
+# Cleanse output file of elements that are specific to where the code is run
+egrep -v package_id $OUTDIR/solr-docs/solr_doc_0.xml | egrep -v file_ref_location | egrep -v file_ref_url > solr_doc_actual.xml
+
+# Diff
+test=$(diff solr_doc_actual.xml $SOLR_EXPECTED)
+if [ -z "$test" ]; then
+    echo "[SUCCESS] Harvest Solr Doc Diff Successful"
+else
+    echo "[ERROR] Harvest Solr Doc Diff Test Failed"
+    echo $test
+    exit 1
+fi
+
+
+# Load test data
+echo "[INFO] Registry Manager Load"
+$LEGACY_REGISTRY_HOME/bin/registry-mgr-solr $OUTDIR
+
+check_status $? "[ERROR] Registry Manager Load Failure"
 
 echo "+++ Test 2 - PDS3 +++"
 TEST_DATA_HOME=$PARENTDIR/src/test/resources/data/test2/junosru/
 #TEST_DATA_HOME=${TEST_DATA_HOME//\//\\\/}
 OUTDIR=$DATA_HOME/test2
 mkdir -p $OUTDIR
-
-# Create config file based upon current environment
-#sed "s/{TEST_DATA_HOME}/$TEST_DATA_HOME/g" $PARENTDIR/src/test/resources/conf/harvest-policy-master.xml > test-policy.xml
-#echo "[INFO] Created new config file with TEST_DATA_HOME=$TEST_DATA_HOME"
 
 echo "[INFO] Parse test data with Catalog Tool"
 $LEGACY_CATALOG_HOME/bin/catalog-solr --mode ingest \
@@ -85,7 +81,7 @@ echo "[SUCCESS] Catalog Solr Successful"
 echo "[INFO] Check solr docs match expected"
 SOLR_EXPECTED=$PARENTDIR/src/test/resources/data/test2/expected/solr_doc_expected.xml
 # Cleanse output file of elements that are specific to where the code is run
-egrep -v package_id $OUTDIR/usa_nasa_pds_jnosru_0xxx__jnosruedr.solr.xml | egrep -v file_ref_location | egrep -v file_ref_url > solr_doc_actual.xml
+egrep -v package_id $OUTDIR/usa_nasa_pds_jnosru_0xxx__jnosruedr.solr.xml | egrep -v file_ref_location | egrep -v file_ref_url | egrep -v modification_date > solr_doc_actual.xml
 
 # Diff
 test=$(diff solr_doc_actual.xml $SOLR_EXPECTED)


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Update configs and CollectionMetExtractor to support new `page_type` field.

* Update Harvest and Catalog configs to include `page_type`
* For collections, added some custom code in order to support Document Collections = Resource and all other Collections = Data Collection

## ⚙️ Test Data and/or Report
* Smoke tests executed successfully
* Additional local tests completed successfully
* Will be further tested when deployed and used by Web Implementation Team

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #118 

