### PR TITLE
Updates to only output LIDs for context references

### DIFF
--- a/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/constants/Constants.java
+++ b/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/constants/Constants.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.harvest.search.constants;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,6 +24,11 @@ public class Constants {
   public static final String BUNDLE = "Product_Bundle";
 
   public static final String COLLECTION = "Product_Collection";
+
+  public static final List<String> CONTEXT_REFS =
+      Arrays.asList(
+          new String[] {"investigation_ref", "instrument_host_ref", "instrument_ref", "target_ref",
+              "facility_ref", "telescope_ref", "observatory_ref", "node_ref", "agency_ref"});
 
   /** The LID in a product label. */
   public static final String LOGICAL_ID = "logical_identifier";

--- a/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/crawler/metadata/extractor/Pds4MetExtractor.java
+++ b/harvest-legacy/src/main/java/gov/nasa/pds/harvest/search/crawler/metadata/extractor/Pds4MetExtractor.java
@@ -278,7 +278,7 @@ public class Pds4MetExtractor implements MetExtractor {
         // multiple lidvids that are associated to a single reference type)
         for (LidVid lidvid : lidvids) {
           ReferenceEntry re = new ReferenceEntry();
-          if (lidvid.hasVersion()) {
+          if (lidvid.hasVersion() && !Constants.CONTEXT_REFS.contains(refTypeMap)) {
             re.setLogicalID(lidvid.getLid());
             re.setVersion(lidvid.getVersion());
           } else {

--- a/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/context.xml
+++ b/harvest-legacy/src/main/resources/conf/search/defaults/pds/pds4/context.xml
@@ -29,6 +29,16 @@
       <registryPath>name</registryPath>
     </field>
     <field name="description" type="required">
+      <registryPath>agency_description</registryPath>
+      <registryPath>airborne_description</registryPath>
+      <registryPath>facility_description</registryPath>
+      <registryPath>instrument_description</registryPath>
+      <registryPath>instrument_host_description</registryPath>
+      <registryPath>investigation_description</registryPath>
+      <registryPath>node_description</registryPath>
+      <registryPath>other_description</registryPath>
+      <registryPath>target_description</registryPath>
+      <registryPath>telescope_description</registryPath>
       <registryPath>citation_description</registryPath>
       <registryPath>resource_description</registryPath>
     </field>

--- a/harvest-legacy/src/main/resources/policy/global-policy.xml
+++ b/harvest-legacy/src/main/resources/policy/global-policy.xml
@@ -2427,6 +2427,9 @@
          instrument_host_to_investigation
        </modelValue>
        <modelValue>
+         instrument_to_investigation
+       </modelValue>
+       <modelValue>
          resource_to_investigation
        </modelValue>
        <modelValue>

--- a/harvest-legacy/src/main/resources/policy/global-policy.xml
+++ b/harvest-legacy/src/main/resources/policy/global-policy.xml
@@ -2627,6 +2627,11 @@
          has_volume
        </modelValue>
      </referenceTypeMap>
+     <referenceTypeMap harvest:value="ancillary_ref">
+       <modelValue>
+         collection_to_ancillary
+       </modelValue>
+     </referenceTypeMap>
   </references>
 
   <fileTypes>


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
* [Updates to only output LIDs for context references](https://github.com/NASA-PDS/registry-legacy-solr/commit/a865e966464d7fa5286b7043b2dc24a13c5b3c9d)
* [Add missing instrument_to_investigation mapping](https://github.com/NASA-PDS/registry-legacy-solr/commit/91c5dd50c9181e12a63f1f79401733813add5894)
* [Fix for missing context descriptions](https://github.com/NASA-PDS/registry-legacy-solr/commit/31e7338274fada5fde78fea93fe77d59c1746462)


## Testing
<img width="672" alt="Screenshot 2024-10-11 at 11 32 32 AM" src="https://github.com/user-attachments/assets/47be76be-43cb-42b7-96e7-1fc08b1235f9">

(chandrayaan LID used to be a LIDVID)